### PR TITLE
Update upload-artifact to version 4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -131,7 +131,7 @@ runs:
       shell: bash
     
     - name: Uploading Qualys WAS Scan Result
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Qualys_WAS_Scan_Result
         path: ./outputs


### PR DESCRIPTION
This is breaking the action. v3 has been deprecated:

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

The error is:

Download action repository 'Qualys/github-action-qwas@v1.0.1' 
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: 
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/